### PR TITLE
handle alleles separated by '|' in MIP7

### DIFF
--- a/genotype/load/vcf.py
+++ b/genotype/load/vcf.py
@@ -48,6 +48,7 @@ def load_vcf(vcf_file, snps):
 def variant_genotypes(sample_ids, variant):
     """Build Genotype objects from a BCF variant."""
     for sample_id, bases in zip(sample_ids, variant.gt_bases):
+        bases = bases.replace('|', '/')
         allele_1, allele_2 = bases.split('/')
         yield RawGenotype(sample_id, allele_1, allele_2)
 


### PR DESCRIPTION
This PR fixes the problem that bases to consider sometimes are delimited with '/' and sometimes with '|'

**How to test:**
1. install on stage
1. us
1. cg upload genotypes vitalmouse (analysed with MIP7)

**Expected outcome:**
genotypes loaded without errors

- [x] code reviewed by @adrosenbaum 
- [x] tested by @patrikgrenfeldt 
- [x] ok to deploy by @patrikgrenfeldt 

This PR is a patch since it only starts to handle another delimiter that was already defined in the standard
