### PR TITLE
New lib path

### DIFF
--- a/genotype/load/plate.py
+++ b/genotype/load/plate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from path import Path
+from pathlib import Path
 
 from genotype.store.models import Plate
 

--- a/genotype/server/admin.py
+++ b/genotype/server/admin.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
+"""Admin views"""
+from pathlib import Path
 from flask import current_app
 from flask_dance.contrib.google import make_google_blueprint
 from flask_dance.consumer import oauth_authorized
 from flask import flash, redirect, request, session, url_for
 from flask_login import (LoginManager, login_user, login_required, logout_user,
                          AnonymousUserMixin)
-from pathlib import Path
 import ruamel.yaml
 
 

--- a/genotype/server/admin.py
+++ b/genotype/server/admin.py
@@ -5,7 +5,7 @@ from flask_dance.consumer import oauth_authorized
 from flask import flash, redirect, request, session, url_for
 from flask_login import (LoginManager, login_user, login_required, logout_user,
                          AnonymousUserMixin)
-from path import Path
+from pathlib import Path
 import ruamel.yaml
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Reverse-Proxy
 Flask-SQLAlchemy==2.1
 Flask-Alchy
 Flask-Security
-werkzeug
+werkzeug<1.0.0  #due to breaking change
 Flask-Login
 Flask-Dance
 ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ SQLAlchemy
 cyvcf2<0.10.0
 xlrd
 pymysql
-path.py
 pysam
 
 # server


### PR DESCRIPTION
This PR updates a old library path, to its new name, pathlib. The update fixes a breaking change and will be tested on genotype production.

**How to prepare for test**:
- [x] ssh to clinical-db
- [ ] merge [THIS-BRANCH-NAME]
- [ ] install on production of clinical-db:
`bash servers/resources/clinical-db.sclifelab.se/update-genotype-prod.sh `

**How to test**:
- [ ] supervisorctl restart genotype
- [ ] Go to https://genotype.scilifelab.se/

**Expected test outcome**:
- [ ] The website should be up and running.

**Review:**
- [x] code approved by @patrikgrenfeldt 
- [ ] tests executed by
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
