### PR TITLE
Update pip for clinical-db in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       if: type = pull_request
       python: "3.6.2"             # version in prod170926
       install:
-        - pip install pip==9.0.1  # pip version in prod170926
+        - pip install pip==20.0.2  # pip version in P_genotype
         - pip install cython
         - pip install .
       script: pip check

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,39 @@ cache: pip
 
 jobs:
   include:
+    - name: "Coverage"
+      install:
+        - pip install cython
+        - pip install . -r requirements-dev.txt
+      script: coverage run --branch --omit="*.html" --source "$(basename "$PWD")" setup.py test
+      after_success: coveralls
+
     - name: "Tests on python 3.6 (Clinical-db)"
-      if: type = pull_request       # extra tests on PR
+      if: type = pull_request
       python: "3.6.2"   # version in prod170926
-      install: pip install . -r requirements-dev.txt
+      install:
+        - pip install cython
+        - pip install . -r requirements-dev.txt
       script: pytest
 
     - name: "Tests on python 3.7 (Hasta)"
+      if: type = pull_request
       python: "3.7.1"   # version in P_main
-      install: pip install . -r requirements-dev.txt
+      install:
+        - pip install cython
+        - pip install . -r requirements-dev.txt
       script: pytest
 
     - name: "Package install"
       if: type = pull_request
+      install: python setup.py install
+      script: pip check
+
+    - name: "Development dependencies"
+      if: type = pull_request
       install:
         - pip install cython
-        - python setup.py install
+        - pip install . -r requirements-dev.txt
       script: pip check
 
     - name: "Production dependencies on python 3.6 (Clinical-db)"
@@ -40,20 +57,6 @@ jobs:
         - pip install .
       script: pip check
 
-    - name: "Development dependencies"
-      if: type = pull_request
-      install:
-        - pip install cython
-        - pip install . -r requirements-dev.txt
-      script: pip check
-
-    - name: "Coverage"
-      install:
-        - pip install cython
-        - pip install . -r requirements-dev.txt
-      script: coverage run --branch --omit="*.html" --source "$(basename "$PWD")" setup.py test
-      after_success: coveralls
-
     - name: "Code formatting"
       if: type = pull_request
       install: pip install black
@@ -66,7 +69,7 @@ jobs:
 
     - name: "Linting"
       if: type = pull_request
-      install: pip install -r requirements-dev.txt
+      install: pip install . -r requirements-dev.txt
       script: git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
 
 notifications:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,20 +1,33 @@
-bumpversion
+# pytest
+pytest>=5.2     # due to pytest-flask, pytest-cov
+pytest-mock
+
+# coverage
 coverage<5
+pytest-cov
 coveralls
+python-coveralls>=2.9.3     # due to conflict on coverage package
+
+# linting
+git-lint
+pylint
+six~=1.12               # due to astroid
+pycodestyle
+yamllint
+docutils
+html-linter
+tidy
 flake8
+
+# black
+black
+pre-commit
+
 invoke
-pytest
 wheel>=0.23.0
 Sphinx
 sphinx-bootstrap-theme
 sphinxcontrib-napoleon
 ipdb
 ipython
-git-lint
-pylint
-pycodestyle
-yamllint
-docutils
-html-linter
-black
-pre-commit
+bumpversion

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
-click
-PyYAML
+# build
+cython
+
+# database
 Alchy
 SQLAlchemy
+pymysql
+
 cyvcf2<0.10.0
 xlrd
-pymysql
 pysam==0.15.2           # due to inability to rebuild newer pysam version
 
 # server
@@ -18,6 +21,3 @@ werkzeug<1.0.0  #due to breaking change
 Flask-Login
 Flask-Dance
 ruamel.yaml
-
-# indirect dependencies
-six~=1.12 # due to astroid


### PR DESCRIPTION
This PR fixes the pip version used when CI Genotype

**How to test**:
- [x] open travis PR-check
- [x] click on the clinical-db Prod dependency check

**Expected test outcome**:
- [x] check that it installs pip=20.0.2
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @northwestwitch 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
