### PR TITLE
Updates deployment instructions for deployment with CG

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# A list of people who have contributed to Warehouse in order of their
+# A list of people who have contributed to Genotype in order of their
 # first contribution.
 #
 # Uses the format of ``Name <email@domain.tld> (url)`` with the
@@ -8,6 +8,7 @@
 
 ## Development Lead
 * Robin Andeer <robin.andeer@scilifelab.se> (http://www.robinandeer.com/)
+* Måns Magnusson <mans.magnusson@scilifelab.se> (https://www.github.com/moonso)
 
 ## Contributors
 None yet. Why not be the first?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Try to use the follwing format:
 
 ### Fixed
 
+## [3.0.1]
+
+### Changed
+- Update deployment instructions
+
 ## [3.0.0]
 
 ### Added

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -15,13 +15,22 @@ Genotype if following the [GitHub flow][gh-flow] branching model which means tha
 1. Make sure you are on `master` (`git checkout master`) and bump version according to step 1, example: `bumpversion minor`
 1. Push the commit: `git push`
 1. Push the tag: `git push --tags`
+### hasta
 1. First deploy on stage so log into hasta and run:
     - `us`
-    - `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-genotype-stage.sh master`
+    - `cg deploy genotype`
 1. Deploy in productions by running the following commands:
     - `down`
     - `up`
-    - `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-genotype-prod.sh`
+    - `cg deploy genotype`
+### clinical-db
+1. First deploy on stage so log into hasta and run:
+    - `us`
+    - `bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-genotype-stage.sh master`
+1. Deploy in productions by running the following commands:
+    - `down`
+    - `up`
+    - `bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-genotype-prod.sh`
 1. Take a screen shot that includes the name of the environment and publish it as a comment on the PR: ![Deployed][confirm-deploy]
 1. Great job :whale2:
 

--- a/genotype/__init__.py
+++ b/genotype/__init__.py
@@ -7,23 +7,12 @@ Taboo is a tool for comparing genotypes from different assays.
 :copyright: (c) 2014 by Robin Andeer
 :licence: MIT, see LICENCE for more details
 """
-import logging
-from pkg_resources import get_distribution, DistributionNotFound
+try:
+    from importlib import metadata
+except ImportError:
+    # Running on pre-3.8 Python; use importlib-metadata package
+    import importlib_metadata as metadata
 
 __title__ = "genotype"
-__summary__ = "tool for comparing genotypes from different assays."
-__uri__ = "https://github.com/Clinical-Genomics/genotype"
 
-try:
-    __version__ = get_distribution(__title__).version
-except DistributionNotFound:
-    __version__ = None
-
-__author__ = "Robin Andeer"
-__email__ = "robin.andeer@scilifelab.se"
-
-__license__ = "MIT"
-__copyright__ = "Copyright 2015 Robin Andeer"
-
-# the user should dictate what happens when a logging event occurs
-logging.getLogger(__name__).addHandler(logging.NullHandler())
+__version__ = metadata.version(__title__)

--- a/genotype/server/app.py
+++ b/genotype/server/app.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from flask import Flask, render_template, redirect, url_for
-from flask_login import current_user
+from flask import Flask, redirect, render_template, url_for
 from flask_bootstrap import Bootstrap
+from flask_login import current_user
 from flask_reverse_proxy import FlaskReverseProxied
 from werkzeug.contrib.fixers import ProxyFix
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # build
 cython
+importlib_metadata; python_version < '3.8'
 
 # database
 Alchy

--- a/setup.py
+++ b/setup.py
@@ -72,10 +72,7 @@ setup(
     # See: http://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are:
-        #   3 - Alpha
-        #   4 - Beta
-        #   5 - Production/Stable
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         # Indicate who your project is intended for
         "Intended Audience :: Developers",
         "Topic :: Software Development",
@@ -84,6 +81,7 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Environment :: Console",
     ],
 )


### PR DESCRIPTION
This PR updates the deployment instructions and fixes a problem that the wrong version was displayed when running `genotype --version`

**How to prepare for test**:
- [ ] ssh to clinical-db
- [ ] Activate the genotype env, `conda activate S_genotype`
- [ ] Check that the version option displays the wrong version, `genotype --version`
- [ ] Take a screenshot and attach or copy/paste the output.
- [ ] install on stage of clinical-db:`cg update genotype`

**How to test**:
- [ ] Check that the version option displays the correct version, `genotype --version`

**Expected test outcome**:
- [ ] check that the correct version is displayed
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
