### PR TITLE
Feat(CLI): List and inactivate users

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,12 +1,12 @@
 This PR adds/fixes ...
 
 **How to prepare for test**:
-- [ ] ssh to clinical-db
-- [ ] install on stage of clinical-db:
-`bash servers/resources/clinical-db.sclifelab.se/update-cgweb-stage.sh [THIS-BRANCH-NAME]`
+- [ ] ssh to Hasta
+- [ ] install on stage of Hasta:
+`bash servers/resources/hasta.sclifelab.se/update-genotype-stage.sh [THIS-BRANCH-NAME]`
 
 **How to test**:
-- [ ] login on https://clinical-stage.scilifelab.se/
+- [ ] login to ...
 - [ ] click on ...
 
 **Expected test outcome**:
@@ -23,3 +23,7 @@ This [version](https://semver.org/) is a:
 - [ ] **MAJOR** - when you make incompatible API changes
 - [ ] **MINOR** - when you add functionality in a backwards compatible manner
 - [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
+
+Implementation plan:
+- [ ] Deploy to ...
+- [ ] Inform to ...

--- a/genotype/cli/base_cmd.py
+++ b/genotype/cli/base_cmd.py
@@ -11,13 +11,13 @@ import yaml
 from genotype import __title__, __version__
 from genotype.store import api
 
-from .delete_cmd import delete_cmd
+from .delete_cmd import delete_cmd, delete_user
 from .export_cmd import export_sample, export_sample_analysis, snps_cmd
 from .init_cmd import init_cmd
 from .load_cmd import load_cmd
 from .match_cmd import check_cmd, match_cmd
 from .serve import serve_cmd
-from .store_cmd import add_sex, ls, sample, view
+from .store_cmd import add_sex, ls_users, ls, sample, view
 
 LOG = logging.getLogger(__name__)
 
@@ -60,11 +60,13 @@ root.add_command(serve_cmd)
 root.add_command(init_cmd)
 root.add_command(load_cmd)
 root.add_command(delete_cmd)
+root.add_command(delete_user)
 root.add_command(match_cmd)
 root.add_command(check_cmd)
 root.add_command(add_sex)
 root.add_command(view)
 root.add_command(ls)
+root.add_command(ls_users)
 root.add_command(sample)
 root.add_command(export_sample)
 root.add_command(export_sample_analysis)

--- a/genotype/cli/store_cmd.py
+++ b/genotype/cli/store_cmd.py
@@ -7,6 +7,7 @@ import click
 
 from genotype.constants import SEXES, TYPES
 from genotype.store import api
+from genotype.store import models
 
 LOG = logging.getLogger(__name__)
 
@@ -77,6 +78,16 @@ def ls(context, since, limit, offset, missing, plate, no_status):
             click.echo(record.sample_id)
         else:
             click.echo(record.id)
+
+
+@click.command("list-users")
+def ls_users():
+    """List users from the database."""
+
+    query = models.User.query
+
+    for record in query:
+        click.echo(record.email)
 
 
 @click.command()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pymysql
 
 cyvcf2
 xlrd==1.2.0
-pysam==0.15.2           # due to inability to rebuild newer pysam version
+pysam
 pyyaml
 coloredlogs
 click


### PR DESCRIPTION
This PR adds commands to list and inactivate users

**How to prepare for test**:
- [ ] ssh to Hasta
- [ ] install on stage of Hasta:
`bash servers/resources/hasta.sclifelab.se/update-genotype-stage.sh [THIS-BRANCH-NAME]`

**How to test list users**:
- [ ] login to hasta
- [ ] us
- [ ] genotype list-users

**Expected test outcome**:
- [ ] check that users (emails) are listed

---

**How to test inactivate user**:
- [ ] login to hasta
- [ ] us
- [ ] genotype delete-user [email]

**Expected test outcome**:
- [ ] check that user email was prepended with a "_" 

---

- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

Implementation plan:
- [ ] Deploy to Hasta
- [ ] Inform to production
