### PR TITLE
Improved error message for multiple SNP variants found in fetch_snp

### DIFF
--- a/genotype/load/vcf.py
+++ b/genotype/load/vcf.py
@@ -65,5 +65,5 @@ def fetch_snp(vcf: VCF, snp: SNP) -> Variant:
         return variant
     # weird SNP position lookup, not even possible; right?
     raise ValueError(
-        f"Multiple variants {len(variants)} found for SNP at position {pos_str}: {variants}.\n The associated BCF file can be found here: {vcf.fname}"
+        f"Multiple variants {len(variants)} found for SNP at position {pos_str}: {variants}."
     )

--- a/genotype/load/vcf.py
+++ b/genotype/load/vcf.py
@@ -65,5 +65,12 @@ def fetch_snp(vcf: VCF, snp: SNP) -> Variant:
         return variant
     # weird SNP position lookup, not even possible; right?
     raise ValueError(
-        f"Multiple variants {len(variants)} found for SNP at position {pos_str}: {variants}."
+        f"Multiple variants {len(variants)} found for SNP at position {pos_str}: {return_alternatives(variants)}."
     )
+
+
+def return_alternatives(variants: List[Variant]) -> str:
+    alternatives = []
+    for variant in variants:
+        alternatives.append(variant.ALT)
+    return ", ".join(alternatives)

--- a/genotype/load/vcf.py
+++ b/genotype/load/vcf.py
@@ -66,4 +66,4 @@ def fetch_snp(vcf: VCF, snp: SNP) -> Variant:
     # weird SNP position lookup, not even possible; right?
     raise ValueError(
         f"Multiple variants {len(variants)} found for SNP at position {pos_str}: {variants}.\n The associated BCF file can be found here: {vcf.fname}"
-        )
+    )

--- a/genotype/load/vcf.py
+++ b/genotype/load/vcf.py
@@ -56,10 +56,10 @@ def fetch_snp(vcf: VCF, snp: SNP) -> Variant:
     pos_str = "{chrom}:{pos}-{pos}".format(chrom=snp.chrom, pos=snp.pos)
     variants = list(vcf(pos_str))
     if len(variants) == 0:
-        LOG.debug("No variant found for %s", pos_str)
+        LOG.debug(f"No variant found for {pos_str}")
         return None
 
-    if len(variants) == 1:
+    elif len(variants) == 1:
         # everything OK
         variant = variants[0]
         return variant

--- a/genotype/load/vcf.py
+++ b/genotype/load/vcf.py
@@ -65,12 +65,12 @@ def fetch_snp(vcf: VCF, snp: SNP) -> Variant:
         return variant
     # weird SNP position lookup, not even possible; right?
     raise ValueError(
-        f"Multiple variants ({len(variants)}) found for SNP at position {pos_str}: {return_alternatives(variants)}."
+        f"Multiple variants ({len(variants)}) found for SNP at position {pos_str}: {return_multiple_variant_alleles(variants=variants)}."
     )
 
 
-def return_alternatives(variants: List[Variant]) -> str:
-    alternatives = []
+def return_multiple_variant_alleles(variants: List[Variant]) -> str:
+    multiple_variant_alleles: List = []
     for variant in variants:
-        alternatives.append(f"{variant.REF}/{','.join(variant.ALT)}")
-    return ", ".join(alternatives)
+        multiple_variant_alleles.append(f"{variant.REF}/{','.join(variant.ALT)}")
+    return ", ".join(multiple_variant_alleles)

--- a/genotype/load/vcf.py
+++ b/genotype/load/vcf.py
@@ -64,4 +64,4 @@ def fetch_snp(vcf: VCF, snp: SNP) -> Variant:
         variant = variants[0]
         return variant
     # weird SNP position lookup, not even possible; right?
-    raise ValueError("multiple variants found for SNP")
+    raise ValueError(f"Multiple variants {len(variants)} found for SNP at position {pos_str}: {variants}.\n The associated BCF file can be found here: {vcf.fname}")

--- a/genotype/load/vcf.py
+++ b/genotype/load/vcf.py
@@ -72,5 +72,5 @@ def fetch_snp(vcf: VCF, snp: SNP) -> Variant:
 def return_alternatives(variants: List[Variant]) -> str:
     alternatives = []
     for variant in variants:
-        alternatives.append(variant.ALT)
+        alternatives.append(f"{variant.REF}/{','.join(variant.ALT)}")
     return ", ".join(alternatives)

--- a/genotype/load/vcf.py
+++ b/genotype/load/vcf.py
@@ -64,4 +64,6 @@ def fetch_snp(vcf: VCF, snp: SNP) -> Variant:
         variant = variants[0]
         return variant
     # weird SNP position lookup, not even possible; right?
-    raise ValueError(f"Multiple variants {len(variants)} found for SNP at position {pos_str}: {variants}.\n The associated BCF file can be found here: {vcf.fname}")
+    raise ValueError(
+        f"Multiple variants {len(variants)} found for SNP at position {pos_str}: {variants}.\n The associated BCF file can be found here: {vcf.fname}"
+        )

--- a/genotype/load/vcf.py
+++ b/genotype/load/vcf.py
@@ -70,6 +70,7 @@ def fetch_snp(vcf: VCF, snp: SNP) -> Variant:
 
 
 def return_multiple_variant_alleles(variants: List[Variant]) -> str:
+    """Takes in a list of Variant, returns all allele variants as str"""
     multiple_variant_alleles: List = []
     for variant in variants:
         multiple_variant_alleles.append(f"{variant.REF}/{','.join(variant.ALT)}")

--- a/genotype/load/vcf.py
+++ b/genotype/load/vcf.py
@@ -65,7 +65,7 @@ def fetch_snp(vcf: VCF, snp: SNP) -> Variant:
         return variant
     # weird SNP position lookup, not even possible; right?
     raise ValueError(
-        f"Multiple variants {len(variants)} found for SNP at position {pos_str}: {return_alternatives(variants)}."
+        f"Multiple variants ({len(variants)}) found for SNP at position {pos_str}: {return_alternatives(variants)}."
     )
 
 


### PR DESCRIPTION
This PR adds/fixes ...

This PR aims to improve an error message log in _fetch_snp()_ of the VCF.py file.

**How to prepare for test**:
- [x] ssh to Hasta
- [x] install on stage of Hasta:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_genotype -t genotype -b improveErrorMsg`

**How to test**:
- [x] Login to the stage environment. Run "cg upload genotypes safemoose" as this case raises the associated error.     

**Expected test outcome**:
- [x] Check that  the message is understandable. It should list the number of variants found, the position where it is at, the actual variants and the associated bcf file.
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] Tests executed by KSV & CO 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

Implementation plan:
- [ ] Deploy to prod when tested

